### PR TITLE
Fix node deletion & dragging cancellation

### DIFF
--- a/editor/events.js
+++ b/editor/events.js
@@ -134,7 +134,7 @@ canvas.addEventListener('mouseup', (event) => {
     if (isDraggingLine) {
         isDraggingLine = false;
 
-        if (resultOfOutputNoduleClicked[0].connection !== null && resultOfMouseOverNodule[0].connection !== null) {
+        if (resultOfOutputNoduleClicked[0] !== null && resultOfMouseOverNodule[0] !== null) {
             resultOfOutputNoduleClicked[0].connection = resultOfMouseOverNodule[0];
             resultOfMouseOverNodule[0].connection = resultOfOutputNoduleClicked[0];
         }

--- a/editor/events.js
+++ b/editor/events.js
@@ -133,8 +133,12 @@ canvas.addEventListener('mouseup', (event) => {
     document.getElementsByTagName("body")[0].style.cursor = "auto";
     if (isDraggingLine) {
         isDraggingLine = false;
-        resultOfOutputNoduleClicked[0].connection = resultOfMouseOverNodule[0];
-        resultOfMouseOverNodule[0].connection = resultOfOutputNoduleClicked[0];
+
+        if (resultOfOutputNoduleClicked[0].connection !== null && resultOfMouseOverNodule[0].connection !== null) {
+            resultOfOutputNoduleClicked[0].connection = resultOfMouseOverNodule[0];
+            resultOfMouseOverNodule[0].connection = resultOfOutputNoduleClicked[0];
+        }
+
         drawGrid();
     }
 

--- a/editor/events.js
+++ b/editor/events.js
@@ -196,16 +196,12 @@ window.addEventListener('keydown', (event) => {
         newVariable();
     }
     if (event.key === "x" | event.key === "d" | event.key === "Backspace") {
-        //WHY THIS NO WORK AAAAAAA
-        /*
-        for (length = 0; length < selectedNodeBlock.inputs.length; length++) {
-            for (asdf = 0; asdf < selectedNodeBlock.inputs[length].connection.parent.inputs.length; asdf++) {
-                selectedNodeBlock.inputs[length].connection.parent.inputs[asdf].connection = null;
-            }
-            console.log(selectedNodeBlock.inputs[length].connection.parent.inputs);
-            selectedNodeBlock.inputs[length].connection = null;
+        for (const nodule of selectedNodeBlock.inputs.concat(selectedNodeBlock.outputs)) {
+            // this is some black magic trickery, but it makes sense if you synapse really hard
+            nodule.connection.connection = null;
+            nodule.connection = null;
         }
-        */
+
         nodeBlocks.splice(nodeBlocks.indexOf(selectedNodeBlock), 1);
         drawGrid();
     }

--- a/editor/events.js
+++ b/editor/events.js
@@ -201,6 +201,11 @@ window.addEventListener('keydown', (event) => {
     }
     if (event.key === "x" | event.key === "d" | event.key === "Backspace") {
         for (const nodule of selectedNodeBlock.inputs.concat(selectedNodeBlock.outputs)) {
+            // add this condition to prevent null pointer exceptions
+            if (nodule.connection === null) {
+                continue;
+            }
+
             // this is some black magic trickery, but it makes sense if you synapse really hard
             nodule.connection.connection = null;
             nodule.connection = null;


### PR DESCRIPTION
Two polish changes:
1. Fixes #3 - when deleting a node block, the connections to the node block will also delete
2. When cancelling dragging a nodule, the "preview connection" now also disappears. To replicate the issue that this PR fixes, select a nodule, drag it, then, without connecting to another nodule, let go of left click. The connector will remain until the left mouse button is clicked.