### PR TITLE
Arithmetic input flip

### DIFF
--- a/editor/actions.js
+++ b/editor/actions.js
@@ -26,7 +26,7 @@ function newTrigFunction() {
 function newUnaryFunction() {
     nodeBlocks.push(
         new FunctionNode(
-            "Unary Operators", "Absolute Value",
+            "Unary Operator", "Absolute Value",
             [{name: "Input", value: null}],
             [{name: "Output", value: null}]
         )
@@ -48,13 +48,7 @@ function newInput() {
 }
 
 function newOutput() {
-    nodeBlocks.push(
-        new OutputNode(
-            "Output", null,
-            [{name: "Graph", value: null}],
-            []
-        )
-    );
+    nodeBlocks.push(new OutputNode());
 
     drawGrid();
 }
@@ -63,7 +57,6 @@ function newVariable() {
     nodeBlocks.push(
         new ValueNode(
             "Variable", "x",
-            [],
             [{name: "Value", value: "x"}]
         )
     );

--- a/editor/actions.js
+++ b/editor/actions.js
@@ -39,7 +39,6 @@ function newInput() {
     nodeBlocks.push(
         new ValueNode(
             "Input", "5",
-            [],
             [{name: "Value", value: 5}]
         )
     );

--- a/editor/actions.js
+++ b/editor/actions.js
@@ -2,7 +2,7 @@
 function newFunction() {
     nodeBlocks.push(
         new FunctionNode(
-            "Function", "Arithmetic", "Add",
+            "Arithmetic", "Add",
             [{name: "Input 1", value: null}, {name: "Input 2", value: null}],
             [{name: "Output", value: null}]
         )
@@ -14,7 +14,7 @@ function newFunction() {
 function newTrigFunction() {
     nodeBlocks.push(
         new FunctionNode(
-            "Function", "Trigonometry", "Sine",
+            "Trigonometry", "Sine",
             [{name: "Input", value: null}],
             [{name: "Output", value: null}]
         )
@@ -26,7 +26,7 @@ function newTrigFunction() {
 function newUnaryFunction() {
     nodeBlocks.push(
         new FunctionNode(
-            "Function", "Unary Operators", "Absolute Value",
+            "Unary Operators", "Absolute Value",
             [{name: "Input", value: null}],
             [{name: "Output", value: null}]
         )
@@ -38,7 +38,7 @@ function newUnaryFunction() {
 function newInput() {
     nodeBlocks.push(
         new ValueNode(
-            "Input", "Input", "5",
+            "Input", "5",
             [],
             [{name: "Value", value: 5}]
         )
@@ -50,7 +50,7 @@ function newInput() {
 function newOutput() {
     nodeBlocks.push(
         new OutputNode(
-            "Output", "Output", null,
+            "Output", null,
             [{name: "Graph", value: null}],
             []
         )
@@ -62,7 +62,7 @@ function newOutput() {
 function newVariable() {
     nodeBlocks.push(
         new ValueNode(
-            "Variable", "Variable", "x",
+            "Variable", "x",
             [],
             [{name: "Value", value: "x"}]
         )

--- a/editor/draw.js
+++ b/editor/draw.js
@@ -1,6 +1,6 @@
 function resizeCanvas() {
-    canvas.style.width ="100%";
-    canvas.style.height="100%";
+    canvas.style.width = "100%";
+    canvas.style.height = "100%";
     canvas.width = canvas.offsetWidth;
     canvas.height = canvas.offsetHeight;
     canvasWidth = canvas.width;

--- a/editor/draw.js
+++ b/editor/draw.js
@@ -1,6 +1,6 @@
 function resizeCanvas() {
-    canvas.style.width ='100%';
-    canvas.style.height='100%';
+    canvas.style.width ="100%";
+    canvas.style.height="100%";
     canvas.width = canvas.offsetWidth;
     canvas.height = canvas.offsetHeight;
     canvasWidth = canvas.width;
@@ -45,9 +45,9 @@ function drawCircle(ctx, x, y, radius) {
 function drawGrid() {
     ctx.imageSmoothingEnabled = false;
     ctx.clearRect(0, 0, canvasWidth + 5, canvasHeight + 5);
-    ctx.fillStyle = '#1d1d1d';
+    ctx.fillStyle = "#1d1d1d";
     ctx.fillRect(0, 0, canvasWidth, canvasHeight);
-    ctx.fillStyle = '#282828';
+    ctx.fillStyle = "#282828";
 
     for (let y = offsetY % gridSize; y < canvasHeight; y += gridSize) {
         for (let x = offsetX % gridSize; x < canvasWidth; x += gridSize) {
@@ -58,7 +58,7 @@ function drawGrid() {
     }
 
     if (isDraggingLine) {
-        ctx.strokeStyle = 'white';
+        ctx.strokeStyle = "white";
         ctx.lineWidth = 2;
         
         ctx.beginPath();
@@ -87,9 +87,9 @@ function drawGrid() {
     }
 
     if (isDragging) {
-        ctx.strokeStyle = 'white';
+        ctx.strokeStyle = "white";
         ctx.lineWidth = 2;
-        ctx.fillStyle = 'rgba(255, 255, 255, 0.1)';
+        ctx.fillStyle = "rgba(255, 255, 255, 0.1)";
         ctx.beginPath();
         ctx.rect(startX, startY, endX - startX, endY - startY);
         ctx.fill();
@@ -97,17 +97,17 @@ function drawGrid() {
     }
 
     if (isMenuVisible) {
-        ctx.fillStyle = '#181818';
+        ctx.fillStyle = "#181818";
         const menuWidth = 150;
         const menuHeight = menuItems.length * 30 + 10;
         const cornerRadius = 5;
         drawRoundedRect(ctx, menuX, menuY, menuWidth, menuHeight, cornerRadius);
         ctx.fill();
         
-        ctx.fillStyle = 'white';
-        ctx.font = '16px Poppins';
-        ctx.textAlign = 'left';
-        ctx.textBaseline = 'bottom';
+        ctx.fillStyle = "white";
+        ctx.font = "16px Poppins";
+        ctx.textAlign = "left";
+        ctx.textBaseline = "bottom";
         menuItems.forEach((item, index) => {
             ctx.fillText(item, menuX + 10, menuY + 30 * (index + 1));
         });
@@ -116,21 +116,23 @@ function drawGrid() {
 
 function refreshLoop() {
     window.requestAnimationFrame(() => {
-      now = performance.now();
-      while (times.length > 0 && times[0] <= now - 1000) {
-        times.shift();
-      }
-      times.push(now);
-      fps = times.length;
-      refreshLoop();
-      ctx.fillStyle = '#1d1d1d'; //1d1d1d
-      ctx.fillRect(10, 10, 67, 22);
-      ctx.fillStyle = 'white';
-      ctx.font = '16px Poppins';
-      ctx.textAlign = 'left';
-      ctx.textBaseline = 'bottom';
-      ctx.fillText('FPS: ' + fps, 15, 30);
+        let now = performance.now();
+
+        while (times.length > 0 && times[0] <= now - 1000) {
+            times.shift();
+        }
+
+        times.push(now);
+        fps = times.length;
+        refreshLoop();
+        ctx.fillStyle = "#1d1d1d";
+        ctx.fillRect(10, 10, 67, 22);
+        ctx.fillStyle = "white";
+        ctx.font = "16px Poppins";
+        ctx.textAlign = "left";
+        ctx.textBaseline = "bottom";
+        ctx.fillText("FPS: " + fps, 15, 30);
     });
-  }
+}
   
-  refreshLoop();
+refreshLoop();

--- a/editor/draw.js
+++ b/editor/draw.js
@@ -69,22 +69,16 @@ function drawGrid() {
 
     for (const nodeBlock of nodeBlocks) {
         for (const output of nodeBlock.outputs) {
-            if (output.connection !== null) {
-                let index = null;
-                // Iterate through the object keys
-                for (const key in output.connection.parent.inputs) {
-                    if (output.connection.parent.inputs[key] === output.connection) {
-                        index = key;
-                        break;
-                    }
-                }
-                ctx.strokeStyle = 'white';
-                ctx.lineWidth = 2;
-                ctx.beginPath();
-                ctx.moveTo(output.parent.x + 150 + offsetX, output.parent.y + 55 + offsetY);
-                ctx.lineTo(output.connection.parent.x + offsetX, output.connection.parent.y + ( -25 * index ) + 200 - 30 + offsetY);
-                ctx.stroke();
+            if (output.connection === null) {
+                continue;
             }
+
+            ctx.strokeStyle = "white";
+            ctx.lineWidth = 2;
+            ctx.beginPath();
+            ctx.moveTo(output.x, output.y);
+            ctx.lineTo(output.connection.x, output.connection.y);
+            ctx.stroke();
         }
     }
 

--- a/editor/events.js
+++ b/editor/events.js
@@ -1,4 +1,4 @@
-canvas.addEventListener('mousedown', (event) => {
+canvas.addEventListener("mousedown", (event) => {
     mouseDown = true;
 
     if (event.button === 0) {
@@ -55,7 +55,7 @@ canvas.addEventListener('mousedown', (event) => {
     drawGrid();
 });
 
-canvas.addEventListener('mousemove', (event) => {
+canvas.addEventListener("mousemove", (event) => {
     endX = event.clientX - canvas.getBoundingClientRect().left;
     endY = event.clientY - canvas.getBoundingClientRect().top; // mysterious code breaks when touched; not sure why its not defined in main.js
     const cursorX = event.clientX - canvas.getBoundingClientRect().left;
@@ -124,7 +124,7 @@ canvas.addEventListener('mousemove', (event) => {
     }
 });
 
-canvas.addEventListener('mouseup', (event) => {
+canvas.addEventListener("mouseup", (event) => {
     mouseDown = false;
     
     document.getElementsByTagName("body")[0].style.cursor = "auto";
@@ -174,15 +174,15 @@ canvas.addEventListener('mouseup', (event) => {
     drawGrid();
 });
 
-canvas.addEventListener('mouseout', (event) => {
+canvas.addEventListener("mouseout", (event) => {
     if (isDragging) {
         isDragging = false;
         drawGrid();
     }
 });
 
-window.addEventListener('keydown', (event) => {
-    if (event.key === 'Escape') {
+window.addEventListener("keydown", (event) => {
+    if (event.key === "Escape") {
         hideMenu();
     }
     if (event.key === "A") {
@@ -218,12 +218,12 @@ window.addEventListener('keydown', (event) => {
     }
 });
 
-canvas.addEventListener('contextmenu', (event) => {
+canvas.addEventListener("contextmenu", (event) => {
     event.preventDefault(); // Prevent the default context menu
     showMenu(event.clientX - canvas.getBoundingClientRect().left, event.clientY - canvas.getBoundingClientRect().top);
 });
 
-canvas.addEventListener('wheel', (event) => {
+canvas.addEventListener("wheel", (event) => {
     // DO NOT DELETE THIS - IF YOU DELETE THIS YOU WILL GET DELETED
     // const zoomFactor = event.deltaY > 0 ? 0.9 : 1.1; // Zoom in or out based on scroll direction
     // gridSize *= zoomFactor;

--- a/editor/events.js
+++ b/editor/events.js
@@ -24,28 +24,25 @@ canvas.addEventListener("mousedown", (event) => {
             endY = startY;
         }
 
-        // TODO: omg what the heck is this mess of code
         if (clickedNodeBlock instanceof FunctionNode) {
             clickedNodeBlock.cycleNodeType();
         }
 
         resultOfOutputNoduleClicked = isOutputNoduleClicked(selectedNodeBlock, startX, startY);
 
-        let nodeSelected, nodeSelectedIndex;
+        if (resultOfOutputNoduleClicked) {
+            let nodeSelected = resultOfOutputNoduleClicked[0];
 
-        // TODO: remove try/catch and actually fix the *farting* error
-        try {
-            nodeSelected = resultOfOutputNoduleClicked[0];
-            nodeSelectedIndex = resultOfOutputNoduleClicked[1];
-        } catch {}
-
-        if (typeof nodeSelected === "object" && nodeSelected !== undefined && nodeSelected !== null) {
-            isDraggingLine = true;
-            lineStartX = clickedNodeBlock.x + 149 + offsetX;
-            lineStartY = clickedNodeBlock.y + offsetY + 55 + (25 * nodeSelectedIndex);
+            if (typeof nodeSelected === "object" && nodeSelected !== undefined && nodeSelected !== null) {
+                isDraggingLine = true;
+                lineStartX = nodeSelected.x;
+                lineStartY = nodeSelected.y;
+            }
         }
+
         hideMenu();
     }
+
     drawGrid();
 });
 

--- a/editor/events.js
+++ b/editor/events.js
@@ -252,50 +252,24 @@ function getMenuItemAtPosition(x, y) {
 function isOutputNoduleClicked(nodeBlock, x, y) {
     // TODO: move to the Nodule class
 
-    let noduleClicked = null;
-    let noduleClickedIndex = null;
-    if (nodeBlock !== null && x !== null && y !== null) {
-        for (let index = 0; index < nodeBlock.outputs.length; index++) {
-            if (boundsDetection(nodeBlock, startX, startY, 145, 155, (25 * index) + 50, (25 * index) + 65)) {
-                    try {
-                        noduleClicked = nodeBlock.outputs[index];
-                        noduleClickedIndex = index;
-                    } catch {
-                        console.log("The following error was written and defined by Github Copilot. I have no idea what is happening. I simply typed 'bruh' and copilot did the rest: ")
-                        console.log("Bruh moment in the try/catch block in events.js line 168. This is a temporary fix. Please fix this. Thank you. - The Management Team of the Math Function Grapher Project. (TM) (C) 2021. All rights reserved. All trademarks are property of their respective owners.");
-                    }
-                    break;
-                }
+    for (const nodule of nodeBlock.outputs) {
+        if (nodule.collidesWith(x, y)) {
+            return nodule;
         }
-        return noduleClicked;
     }
+
+    return null;
 }
 
 function isMouseOverNodule(nodeBlock, x, y) {
     // TODO: move to a method in the Nodule class
-    let noduleOver = null;
-    let noduleOverIndex = null;
-
-    if (nodeBlock !== null && x !== null && y !== null) {
-        for (let index = 0; index < nodeBlock.inputs.length; index++) {
-            const noduleX = nodeBlock.x + offsetX - 5;
-            const noduleY = nodeBlock.y + ( -25 * index ) + 200 - 35 + offsetY;
-
-            const noduleWidth = 10;
-            const noduleHeight = 10;
-            if (
-                x >= noduleX &&
-                x <= noduleX + noduleWidth &&
-                y >= noduleY &&
-                y <= noduleY + noduleHeight
-            ) {
-                noduleOver = nodeBlock.inputs[index];
-                noduleOverIndex = index;
-                break;
-            }
+    for (const nodule of nodeBlock.inputs) {
+        if (nodule.collidesWith(x, y)) {
+            return nodule;
         }
-        return noduleOver;
     }
+
+    return null;
 }
 
 function showMenu(x, y) {

--- a/editor/events.js
+++ b/editor/events.js
@@ -9,7 +9,7 @@ canvas.addEventListener("mousedown", (event) => {
         let clickedNodeBlock = null;
         selectedNodeBlock = null;
         for (const nodeBlock of nodeBlocks) {
-            if (boundsDetection(nodeBlock, startX, startY, 0, nodeBlock.width + 5, 0, nodeBlock.height)) {
+            if (nodeBlock.collidesWithBlock(startX, startY)) {
                 clickedNodeBlock = nodeBlock;
             }
         }
@@ -63,8 +63,7 @@ canvas.addEventListener("mousemove", (event) => {
 
     let overNodeBlock = null;
     for (const nodeBlock of nodeBlocks) {
-        // TODO: move into the NodeBlock class
-        if (boundsDetection(nodeBlock, cursorX, cursorY, -5, nodeBlock.width + 5, 0, nodeBlock.height)) {
+        if (nodeBlock.collidesWithBlock(cursorX, cursorY)) {
             overNodeBlock = nodeBlock; // Store the clicked node block
         }
     }
@@ -268,8 +267,4 @@ function handleMenuItemClick(itemText) {
     if (functionsByTitle[itemText]) {
         functionsByTitle[itemText]();
     }
-}
-
-function boundsDetection(nodeBlock, xComp, yComp, gtx, ltx, gty, lty) {
-    return xComp >= nodeBlock.x + offsetX + gtx && xComp <= nodeBlock.x + offsetX + ltx && yComp >= nodeBlock.y + offsetY + gty && yComp <= nodeBlock.y + offsetY + lty;
 }

--- a/editor/events.js
+++ b/editor/events.js
@@ -28,15 +28,17 @@ canvas.addEventListener("mousedown", (event) => {
             clickedNodeBlock.cycleNodeType();
         }
 
-        resultOfOutputNoduleClicked = selectedNodeBlock.outputNoduleAt(startX, startY);
+        if (selectedNodeBlock !== null) {
+            resultOfOutputNoduleClicked = selectedNodeBlock.outputNoduleAt(startX, startY);
 
-        if (resultOfOutputNoduleClicked) {
-            let nodeSelected = resultOfOutputNoduleClicked;
+            if (resultOfOutputNoduleClicked) {
+                let nodeSelected = resultOfOutputNoduleClicked;
 
-            if (typeof nodeSelected === "object" && nodeSelected !== undefined && nodeSelected !== null) {
-                isDraggingLine = true;
-                lineStartX = nodeSelected.x;
-                lineStartY = nodeSelected.y;
+                if (typeof nodeSelected === "object" && nodeSelected !== undefined && nodeSelected !== null) {
+                    isDraggingLine = true;
+                    lineStartX = nodeSelected.x;
+                    lineStartY = nodeSelected.y;
+                }
             }
         }
 

--- a/editor/events.js
+++ b/editor/events.js
@@ -174,23 +174,17 @@ canvas.addEventListener("mouseout", (event) => {
 });
 
 window.addEventListener("keydown", (event) => {
-    if (event.key === "Escape") {
-        hideMenu();
+    let keyMap = {
+        "Escape": hideMenu,
+        "A": () => showMenu(endX, endY),
+        "F": newFunction,
+        "R": newInput,
+        "C": newOutput,
+        "V": newVariable,
     }
-    if (event.key === "A") {
-        showMenu(endX, endY);
-    }
-    if (event.key === "F") {
-        newFunction();
-    }
-    if (event.key === "R") {
-        newInput();
-    }
-    if (event.key === "C") {
-        newOutput();
-    }
-    if (event.key === "V") {
-        newVariable();
+
+    if (keyMap[event.key]) {
+        keyMap[event.key]();
     }
 
     if (event.key === "x" || event.key === "d" || event.key === "Backspace" || event.key === "Delete") {

--- a/editor/events.js
+++ b/editor/events.js
@@ -45,12 +45,6 @@ canvas.addEventListener("mousedown", (event) => {
             lineStartY = clickedNodeBlock.y + offsetY + 55 + (25 * nodeSelectedIndex);
         }
         hideMenu();
-
-        if (clickedNodeBlock) {
-            document.getElementById("propertyType").innerHTML = clickedNodeBlock.type;
-            document.getElementById("propertyCategory").innerHTML = clickedNodeBlock.category;
-            document.getElementById("propertyFunction").innerHTML = clickedNodeBlock.getFormula();
-        }
     }
     drawGrid();
 });

--- a/editor/events.js
+++ b/editor/events.js
@@ -1,18 +1,13 @@
 canvas.addEventListener('mousedown', (event) => {
-    if (event.button == 0) {
-        mouseDown = true;
-        startX = event.clientX - canvas.getBoundingClientRect().left; //idk whats goin on around here but i hope it works
+    if (event.button === 0) {
+        startX = event.clientX - canvas.getBoundingClientRect().left; // idk what's going on around here, but I hope it works
         startY = event.clientY - canvas.getBoundingClientRect().top;
         handleMenuItemClick(getMenuItemAtPosition(event.clientX - canvas.getBoundingClientRect().left, event.clientY - canvas.getBoundingClientRect().top));
 
         let clickedNodeBlock = null;
         selectedNodeBlock = null;
         for (const nodeBlock of nodeBlocks) {
-            const x = nodeBlock.x;
-            const y = nodeBlock.y;
-            const blockWidth = 150;
-            const blockHeight = 200;
-            if (boundsDetection(nodeBlock, startX, startY, 0, blockWidth + 5, 0, blockHeight)) {
+            if (boundsDetection(nodeBlock, startX, startY, 0, nodeBlock.width + 5, 0, nodeBlock.height)) {
                 clickedNodeBlock = nodeBlock;
             }
         }
@@ -20,6 +15,7 @@ canvas.addEventListener('mousedown', (event) => {
         if (clickedNodeBlock) {
             selectedNodeBlock = clickedNodeBlock;
         }
+
         if (clickedNodeBlock == null && !event.shiftKey) {
             isDragging = true;
             endX = startX;
@@ -39,9 +35,8 @@ canvas.addEventListener('mousedown', (event) => {
         try {
             nodeSelected = resultOfOutputNoduleClicked[0];
             nodeSelectedIndex = resultOfOutputNoduleClicked[1];
-        } catch {
-            console.log("I love try blocks. They fix all of my errors. Its like even better than cgshat gpt");
-        }
+        } catch {}
+
         if (typeof nodeSelected === "object" && nodeSelected !== undefined && nodeSelected !== null) {
             isDraggingLine = true;
             lineStartX = clickedNodeBlock.x + 149 + offsetX;
@@ -64,7 +59,7 @@ canvas.addEventListener('mousemove', (event) => {
     const cursorX = event.clientX - canvas.getBoundingClientRect().left;
     const cursorY = event.clientY - canvas.getBoundingClientRect().top;
 
-    if (event.buttons === 4 | (event.buttons === 1 && event.shiftKey)) {
+    if (event.buttons === 4 || (event.buttons === 1 && event.shiftKey)) {
         document.getElementsByTagName("body")[0].style.cursor = "all-scroll";
         offsetX += event.movementX;
         offsetY += event.movementY;
@@ -108,7 +103,7 @@ canvas.addEventListener('mousemove', (event) => {
         }
 
         drawGrid();
-    } else if (selectedNodeBlock && !isDragging && mouseDown == 1 && !event.shiftKey) {
+    } else if (selectedNodeBlock && !isDragging && mouseDown === 1 && !event.shiftKey) {
         const deltaX = cursorX - startX;
         const deltaY = cursorY - startY;
 
@@ -227,20 +222,19 @@ canvas.addEventListener('contextmenu', (event) => {
 });
 
 canvas.addEventListener('wheel', (event) => {
-    /* DO NOT DELETE | IF YOU DELETE THIS YOU WILL GET DELETED
-    const zoomFactor = event.deltaY > 0 ? 0.9 : 1.1; // Zoom in or out based on scroll direction
-    gridSize *= zoomFactor;
-    scale = gridSize / 20;
-
-    // Limit the minimum and maximum grid size
-    if (gridSize < 10) {
-        gridSize = 10; // Minimum grid size
-    } else if (gridSize > 100) {
-        gridSize = 100; // Maximum grid size
-    }
-
-    drawGrid();
-    */
+    // DO NOT DELETE THIS - IF YOU DELETE THIS YOU WILL GET DELETED
+    // const zoomFactor = event.deltaY > 0 ? 0.9 : 1.1; // Zoom in or out based on scroll direction
+    // gridSize *= zoomFactor;
+    // scale = gridSize / 20;
+    //
+    // // Limit the minimum and maximum grid size
+    // if (gridSize < 10) {
+    //     gridSize = 10; // Minimum grid size
+    // } else if (gridSize > 100) {
+    //     gridSize = 100; // Maximum grid size
+    // }
+    //
+    // drawGrid();
 });
 
 function getMenuItemAtPosition(x, y) {
@@ -313,37 +307,28 @@ function isMouseOverNodule(nodeBlock, x, y) {
 
 function handleNodeTypeChange(nodeBlockToChange) {
     //x + 15, y + 75, blockWidth - 30, blockHeight - 170
-    if (nodeBlockToChange.type == "Function") {
+    if (nodeBlockToChange.type === "Function") {
         if (startX >= nodeBlockToChange.x + 15 + offsetX &&
             startX <= nodeBlockToChange.x + 150 - 15 + offsetX &&
             startY >= nodeBlockToChange.y + 75 + offsetY &&
             startY <= nodeBlockToChange.y + 200 - 100 + offsetY)
         {
-            if (nodeBlockToChange.category == "Arithmetic") {
-                let operations = ["Add", "Subtract", "Multiply", "Divide", "Modulus", "Exponent", "Radical", "Logarithm", "RESET"];
-                if (operations[operations.indexOf(nodeBlockToChange.operationtype) + 1] == "RESET") {
-                    nodeBlockToChange.operationtype = operations[0]
-                } else if (nodeBlockToChange.operationtype == operations[operations.indexOf(nodeBlockToChange.operationtype)]) {
-                    nodeBlockToChange.operationtype = operations[operations.indexOf(nodeBlockToChange.operationtype) + 1];
-                }
+            let operationsByCategory = {
+                "Arithmetic": ["Add", "Subtract", "Multiply", "Divide", "Exponent", "Modulus", "Radical", "Logarithm"],
+                "Unary Operators": ["Absolute Value", "Ceiling", "Floor"],
+                "Trigonometry": ["Sine", "Cosine", "Tangent", "Cosecant", "Secant", "Cotangent"]
             }
-            if (nodeBlockToChange.category == "Unary Operators") {
-                let operations = ["Absolute Value", "Ceiling", "Floor", "RESET"];
-                //let operations = ["Absolute Value", "Factorial", "Ceiling", "Floor", "RESET"]; (copy of above line with factorial)
-                if (operations[operations.indexOf(nodeBlockToChange.operationtype) + 1] == "RESET") {
-                    nodeBlockToChange.operationtype = operations[0]
-                } else if (nodeBlockToChange.operationtype == operations[operations.indexOf(nodeBlockToChange.operationtype)]) {
-                    nodeBlockToChange.operationtype = operations[operations.indexOf(nodeBlockToChange.operationtype) + 1];
-                }
+
+            let operations = operationsByCategory[nodeBlockToChange.category];
+            let operationTypeIndex = operations.indexOf(nodeBlockToChange.operationtype);
+            let newOperationIndex = operationTypeIndex + 1;
+
+            // "Roll over" the operations array
+            if (newOperationIndex === operations.length - 1) {
+                newOperationIndex = 0;
             }
-            if (nodeBlockToChange.category == "Trigonometry") {
-                let operations = ["Sine", "Cosine", "Tangent", "Cosecant", "Secant", "Cotangent", "RESET"];
-                if (operations[operations.indexOf(nodeBlockToChange.operationtype) + 1] == "RESET") {
-                    nodeBlockToChange.operationtype = operations[0]
-                } else if (nodeBlockToChange.operationtype == operations[operations.indexOf(nodeBlockToChange.operationtype)]) {
-                    nodeBlockToChange.operationtype = operations[operations.indexOf(nodeBlockToChange.operationtype) + 1];
-                }
-            }
+
+            nodeBlockToChange.operationtype = operations[newOperationIndex];
         }
     }
 }
@@ -380,6 +365,6 @@ function handleMenuItemClick(itemText) {
     }
 }
 
-function boundsDetection(nodeBlock, xcomp, ycomp, gtx, ltx, gty, lty) {
-    return xcomp >= nodeBlock.x + offsetX + gtx && xcomp <= nodeBlock.x + offsetX + ltx && ycomp >= nodeBlock.y + offsetY + gty && ycomp <= nodeBlock.y + offsetY + lty;
+function boundsDetection(nodeBlock, xComp, yComp, gtx, ltx, gty, lty) {
+    return xComp >= nodeBlock.x + offsetX + gtx && xComp <= nodeBlock.x + offsetX + ltx && yComp >= nodeBlock.y + offsetY + gty && yComp <= nodeBlock.y + offsetY + lty;
 }

--- a/editor/events.js
+++ b/editor/events.js
@@ -1,7 +1,7 @@
 canvas.addEventListener("mousedown", (event) => {
-    mouseDown = true;
-
     if (event.button === 0) {
+        mouseDown = true;
+
         startX = event.clientX - canvas.getBoundingClientRect().left; // idk what's going on around here, but I hope it works
         startY = event.clientY - canvas.getBoundingClientRect().top;
         handleMenuItemClick(getMenuItemAtPosition(event.clientX - canvas.getBoundingClientRect().left, event.clientY - canvas.getBoundingClientRect().top));

--- a/editor/events.js
+++ b/editor/events.js
@@ -1,4 +1,6 @@
 canvas.addEventListener('mousedown', (event) => {
+    mouseDown = true;
+
     if (event.button === 0) {
         startX = event.clientX - canvas.getBoundingClientRect().left; // idk what's going on around here, but I hope it works
         startY = event.clientY - canvas.getBoundingClientRect().top;
@@ -23,8 +25,8 @@ canvas.addEventListener('mousedown', (event) => {
         }
 
         // TODO: omg what the heck is this mess of code
-        if (clickedNodeBlock) {
-            handleNodeTypeChange(clickedNodeBlock);
+        if (clickedNodeBlock instanceof FunctionNode) {
+            clickedNodeBlock.cycleNodeType();
         }
 
         resultOfOutputNoduleClicked = isOutputNoduleClicked(selectedNodeBlock, startX, startY);
@@ -103,7 +105,7 @@ canvas.addEventListener('mousemove', (event) => {
         }
 
         drawGrid();
-    } else if (selectedNodeBlock && !isDragging && mouseDown === 1 && !event.shiftKey) {
+    } else if (selectedNodeBlock && !isDragging && mouseDown === true && !event.shiftKey) {
         const deltaX = cursorX - startX;
         const deltaY = cursorY - startY;
 
@@ -302,34 +304,6 @@ function isMouseOverNodule(nodeBlock, x, y) {
             }
         }
         return [noduleOver, noduleOverIndex];
-    }
-}
-
-function handleNodeTypeChange(nodeBlockToChange) {
-    //x + 15, y + 75, blockWidth - 30, blockHeight - 170
-    if (nodeBlockToChange.type === "Function") {
-        if (startX >= nodeBlockToChange.x + 15 + offsetX &&
-            startX <= nodeBlockToChange.x + 150 - 15 + offsetX &&
-            startY >= nodeBlockToChange.y + 75 + offsetY &&
-            startY <= nodeBlockToChange.y + 200 - 100 + offsetY)
-        {
-            let operationsByCategory = {
-                "Arithmetic": ["Add", "Subtract", "Multiply", "Divide", "Exponent", "Modulus", "Radical", "Logarithm"],
-                "Unary Operators": ["Absolute Value", "Ceiling", "Floor"],
-                "Trigonometry": ["Sine", "Cosine", "Tangent", "Cosecant", "Secant", "Cotangent"]
-            }
-
-            let operations = operationsByCategory[nodeBlockToChange.category];
-            let operationTypeIndex = operations.indexOf(nodeBlockToChange.operationtype);
-            let newOperationIndex = operationTypeIndex + 1;
-
-            // "Roll over" the operations array
-            if (newOperationIndex === operations.length - 1) {
-                newOperationIndex = 0;
-            }
-
-            nodeBlockToChange.operationtype = operations[newOperationIndex];
-        }
     }
 }
 

--- a/editor/events.js
+++ b/editor/events.js
@@ -64,12 +64,7 @@ canvas.addEventListener("mousemove", (event) => {
     let overNodeBlock = null;
     for (const nodeBlock of nodeBlocks) {
         // TODO: move into the NodeBlock class
-
-        // AABB collision (what is aabb)
-        if (
-            boundsDetection(nodeBlock, cursorX, cursorY, -5, nodeBlock.width + 5, 0, nodeBlock.height)
-            // 
-        ) {
+        if (boundsDetection(nodeBlock, cursorX, cursorY, -5, nodeBlock.width + 5, 0, nodeBlock.height)) {
             overNodeBlock = nodeBlock; // Store the clicked node block
         }
     }

--- a/editor/events.js
+++ b/editor/events.js
@@ -28,7 +28,7 @@ canvas.addEventListener("mousedown", (event) => {
             clickedNodeBlock.cycleNodeType();
         }
 
-        resultOfOutputNoduleClicked = isOutputNoduleClicked(selectedNodeBlock, startX, startY);
+        resultOfOutputNoduleClicked = selectedNodeBlock.outputNoduleAt(startX, startY);
 
         if (resultOfOutputNoduleClicked) {
             let nodeSelected = resultOfOutputNoduleClicked;
@@ -48,7 +48,7 @@ canvas.addEventListener("mousedown", (event) => {
 
 canvas.addEventListener("mousemove", (event) => {
     endX = event.clientX - canvas.getBoundingClientRect().left;
-    endY = event.clientY - canvas.getBoundingClientRect().top; // mysterious code breaks when touched; not sure why its not defined in main.js
+    endY = event.clientY - canvas.getBoundingClientRect().top; // mysterious code breaks when touched; not sure why it's not defined in main.js
     const cursorX = event.clientX - canvas.getBoundingClientRect().left;
     const cursorY = event.clientY - canvas.getBoundingClientRect().top;
 
@@ -60,7 +60,6 @@ canvas.addEventListener("mousemove", (event) => {
     }
 
     let overNodeBlock = null;
-    overNodeBlock = null;
     for (const nodeBlock of nodeBlocks) {
         // TODO: move into the NodeBlock class
 
@@ -80,7 +79,7 @@ canvas.addEventListener("mousemove", (event) => {
         lineEndY = endY;
         
         if (overNodeBlock !== null) {
-            resultOfMouseOverNodule = isMouseOverNodule(overNodeBlock, cursorX, cursorY);
+            resultOfMouseOverNodule = overNodeBlock.inputNoduleAt(cursorX, cursorY);
         }
 
         drawGrid();
@@ -246,30 +245,6 @@ function getMenuItemAtPosition(x, y) {
     } else {
         return null;
     }
-    
-}
-
-function isOutputNoduleClicked(nodeBlock, x, y) {
-    // TODO: move to the Nodule class
-
-    for (const nodule of nodeBlock.outputs) {
-        if (nodule.collidesWith(x, y)) {
-            return nodule;
-        }
-    }
-
-    return null;
-}
-
-function isMouseOverNodule(nodeBlock, x, y) {
-    // TODO: move to a method in the Nodule class
-    for (const nodule of nodeBlock.inputs) {
-        if (nodule.collidesWith(x, y)) {
-            return nodule;
-        }
-    }
-
-    return null;
 }
 
 function showMenu(x, y) {

--- a/editor/events.js
+++ b/editor/events.js
@@ -31,7 +31,7 @@ canvas.addEventListener("mousedown", (event) => {
         resultOfOutputNoduleClicked = isOutputNoduleClicked(selectedNodeBlock, startX, startY);
 
         if (resultOfOutputNoduleClicked) {
-            let nodeSelected = resultOfOutputNoduleClicked[0];
+            let nodeSelected = resultOfOutputNoduleClicked;
 
             if (typeof nodeSelected === "object" && nodeSelected !== undefined && nodeSelected !== null) {
                 isDraggingLine = true;
@@ -122,9 +122,9 @@ canvas.addEventListener("mouseup", (event) => {
     if (isDraggingLine) {
         isDraggingLine = false;
 
-        if (resultOfOutputNoduleClicked[0] !== null && resultOfMouseOverNodule[0] !== null) {
-            resultOfOutputNoduleClicked[0].connection = resultOfMouseOverNodule[0];
-            resultOfMouseOverNodule[0].connection = resultOfOutputNoduleClicked[0];
+        if (resultOfOutputNoduleClicked !== null && resultOfMouseOverNodule !== null) {
+            resultOfOutputNoduleClicked.connection = resultOfMouseOverNodule;
+            resultOfMouseOverNodule.connection = resultOfOutputNoduleClicked;
         }
 
         drawGrid();
@@ -267,7 +267,7 @@ function isOutputNoduleClicked(nodeBlock, x, y) {
                     break;
                 }
         }
-        return [noduleClicked, noduleClickedIndex];
+        return noduleClicked;
     }
 }
 
@@ -294,7 +294,7 @@ function isMouseOverNodule(nodeBlock, x, y) {
                 break;
             }
         }
-        return [noduleOver, noduleOverIndex];
+        return noduleOver;
     }
 }
 

--- a/editor/main.js
+++ b/editor/main.js
@@ -33,8 +33,8 @@ const menuItems = ['Variable', 'Arithmetic', 'Trigonometry', 'Unary Operators', 
 const nodeBlocks = []; 
 let selectedNodeBlock = null;
 
-let resultOfOutputNoduleClicked = [];  // Array to store the result of where the user is dragging from
-let resultOfMouseOverNodule = [];  // Array to store the result of where the user is dragging to (what nodule the user is hovering over)
+let resultOfOutputNoduleClicked = null;  // Array to store the result of where the user is dragging from
+let resultOfMouseOverNodule = null;  // Array to store the result of where the user is dragging to (what nodule the user is hovering over)
 
 canvas.width = canvas.clientWidth;
 canvas.height = canvas.clientHeight;

--- a/editor/main.js
+++ b/editor/main.js
@@ -16,7 +16,7 @@ let offsetY = 0;
 let isDragging = false;
 let startX, startY, endX, endY;
 // Node: StartX/Y are defined ON MOUSE DOWN, endX/Y are defined ON MOUSE MOVE
-// used to compute change of canvas offset + alot of other stuff
+// used to compute change of canvas offset + a lot of other stuff
 
 let isMenuVisible = false;
 let menuX = 0; // position of menu

--- a/editor/main.js
+++ b/editor/main.js
@@ -25,7 +25,6 @@ let menuY = 0;
 const times = [];
 let fps;
 
-let nodeSelected, nodeOver = null;
 let isDraggingLine = false;
 let lineStartX, lineStartY, lineEndX, lineEndY; // Line dragging
 
@@ -34,31 +33,28 @@ const functionMenuItems = [
     [["Arithmetic"], ["Add", "Subtract", "Multiply", "Divide", "Exponent", "Modulus", "Radical", "Logarithm"]],
     [["Unary Operators"], ["Absolute Value", "Ceiling", "Floor"]], 
     // [["Unary Operators"], ["Absolute Value", "Factorial", "Ceiling", "Floor"]], (Copy of above line with factorial)
-    //["Linear Algebra", ["Cross Product", "Magnitude", "Dot Product", "Matrix Multiply", "Matix Transpose", "Matrix Determinant"]], 
-    //["Calculus", ["Limit", "Integral", "Derivative", "Gradient", "Summation", "Product"]],
+    // ["Linear Algebra", ["Cross Product", "Magnitude", "Dot Product", "Matrix Multiply", "Matix Transpose", "Matrix Determinant"]],
+    // ["Calculus", ["Limit", "Integral", "Derivative", "Gradient", "Summation", "Product"]],
     // [["Boolean Logic"], ["And", "Or", "Exclusive Or", "Logical Implies", "Negotiation", "Less Than", "Greater Than", "Equal"]],
-    //["Set", ["Union", "Intersection", "Set Difference", "Subset", "Superset", "Proper Superset", "Element Of"]],
+    // ["Set", ["Union", "Intersection", "Set Difference", "Subset", "Superset", "Proper Superset", "Element Of"]],
     [["Trigonometry"], ["Sine", "Cosine", "Tangent", "Cosecant", "Secant", "Cotangent", "Inverse Sine", "Inverse Cosine", "Inverse Tangent", "Inverse Cosecant", "Inverse Secant", "Inverse Cotangent"]]
-    //["Statistics", ["Mean", "Median", "Minimum", "Maximum", "Quartile", "Quantile", "Standard Deviation", "Variance", "Mean Absolute Deviation", "Correlation", "Spearman", "Count", "Total"]],
-    //["List Operations", ["Join", "Sort", "Shuffle", "Unique", "For"]],
-    //["Visualizations", ["Histogram", "Dotplot", "Boxplot"]],
-    //["Distributions", ["Normal", "Students", "Poisson", "Binomial", "Uniform", "PDF", "CDF"]],
-    //["Number Theory", ["Least Common Multiple", "Greatest Common Denominator", "Round", "Sign", "nPr", "nCr"]]
+    // ["Statistics", ["Mean", "Median", "Minimum", "Maximum", "Quartile", "Quantile", "Standard Deviation", "Variance", "Mean Absolute Deviation", "Correlation", "Spearman", "Count", "Total"]],
+    // ["List Operations", ["Join", "Sort", "Shuffle", "Unique", "For"]],
+    // ["Visualizations", ["Histogram", "Dotplot", "Boxplot"]],
+    // ["Distributions", ["Normal", "Students", "Poisson", "Binomial", "Uniform", "PDF", "CDF"]],
+    // ["Number Theory", ["Least Common Multiple", "Greatest Common Denominator", "Round", "Sign", "nPr", "nCr"]]
 ];
 
 const nodeBlocks = []; 
-let selectedNodeBlock = null; // i have no idea what this does but if i touch it it breaks instantly
-let isBoxSelecting = false; 
-let isDraggingNodeBlock = false;
+let selectedNodeBlock = null;
 
-let resultOfOutputNoduleClicked = []; // Array to store the result of where the user is dragging from
-let resultOfMouseOverNodule = []; // Array to store the result of where the user is dragging to (what nodule the user is hovering over)
+let resultOfOutputNoduleClicked = [];  // Array to store the result of where the user is dragging from
+let resultOfMouseOverNodule = [];  // Array to store the result of where the user is dragging to (what nodule the user is hovering over)
 
 canvas.width = canvas.clientWidth;
 canvas.height = canvas.clientHeight;
 
-const selectedBlocks = []; // all the node blocks that are selected (still only has one at a time :[ )
-let boxSelectStartX, boxSelectStartY; // Box selection start
+const selectedBlocks = [];  // all the node blocks that are selected (still only has one at a time :[ )
 
 ctx.imageSmoothingEnabled = false;
 

--- a/editor/main.js
+++ b/editor/main.js
@@ -29,21 +29,6 @@ let isDraggingLine = false;
 let lineStartX, lineStartY, lineEndX, lineEndY; // Line dragging
 
 const menuItems = ['Variable', 'Arithmetic', 'Trigonometry', 'Unary Operators', 'Input', 'Output'];
-const functionMenuItems = [
-    [["Arithmetic"], ["Add", "Subtract", "Multiply", "Divide", "Exponent", "Modulus", "Radical", "Logarithm"]],
-    [["Unary Operators"], ["Absolute Value", "Ceiling", "Floor"]], 
-    // [["Unary Operators"], ["Absolute Value", "Factorial", "Ceiling", "Floor"]], (Copy of above line with factorial)
-    // ["Linear Algebra", ["Cross Product", "Magnitude", "Dot Product", "Matrix Multiply", "Matix Transpose", "Matrix Determinant"]],
-    // ["Calculus", ["Limit", "Integral", "Derivative", "Gradient", "Summation", "Product"]],
-    // [["Boolean Logic"], ["And", "Or", "Exclusive Or", "Logical Implies", "Negotiation", "Less Than", "Greater Than", "Equal"]],
-    // ["Set", ["Union", "Intersection", "Set Difference", "Subset", "Superset", "Proper Superset", "Element Of"]],
-    [["Trigonometry"], ["Sine", "Cosine", "Tangent", "Cosecant", "Secant", "Cotangent", "Inverse Sine", "Inverse Cosine", "Inverse Tangent", "Inverse Cosecant", "Inverse Secant", "Inverse Cotangent"]]
-    // ["Statistics", ["Mean", "Median", "Minimum", "Maximum", "Quartile", "Quantile", "Standard Deviation", "Variance", "Mean Absolute Deviation", "Correlation", "Spearman", "Count", "Total"]],
-    // ["List Operations", ["Join", "Sort", "Shuffle", "Unique", "For"]],
-    // ["Visualizations", ["Histogram", "Dotplot", "Boxplot"]],
-    // ["Distributions", ["Normal", "Students", "Poisson", "Binomial", "Uniform", "PDF", "CDF"]],
-    // ["Number Theory", ["Least Common Multiple", "Greatest Common Denominator", "Round", "Sign", "nPr", "nCr"]]
-];
 
 const nodeBlocks = []; 
 let selectedNodeBlock = null;

--- a/editor/uiclasses.js
+++ b/editor/uiclasses.js
@@ -267,6 +267,16 @@ class Node {
 
         return null;
     }
+
+    /**
+     * @param x The x coordinate to check collision for
+     * @param y The y coordinate to check collision for
+     * @returns {boolean} Whether the given x and y coordinates collide with the node block
+     */
+    collidesWithBlock(x, y) {
+        return x >= this.x + offsetX && x <= this.x + this.width + offsetX
+            && y >= this.y + offsetY && y <= this.y + this.height + offsetY;
+    }
 }
 
 class ValueNode extends Node {

--- a/editor/uiclasses.js
+++ b/editor/uiclasses.js
@@ -270,8 +270,8 @@ class Node {
 }
 
 class ValueNode extends Node {
-    constructor(category, operationtype, inputs, outputs) {
-        super(category, operationtype, inputs, outputs);
+    constructor(category, operationtype, outputs) {
+        super(category, operationtype, outputs);
         this.value = operationtype;
     }
 
@@ -394,8 +394,8 @@ class FunctionNode extends Node {
 }
 
 class OutputNode extends Node {
-    constructor(category, operationtype, inputs, outputs) {
-        super(category, operationtype, inputs, outputs);
+    constructor() {
+        super("Output", null, [{name: "Graph", value: null}], []);
     }
 
     getFormula() {

--- a/editor/uiclasses.js
+++ b/editor/uiclasses.js
@@ -27,20 +27,18 @@ class Nodule {
 
 class Node {
     /**
-     * @param type The type of node.
      * @param category The category of node.
      * @param operationtype The operation type of the node. (null if not applicable, e.g., a value node)
      * @param inputs An array of objects. Each object has a title "name" and a value "value".
      * @param outputs An array of objects. Each object has a title "name" and a value "value".
      */
-    constructor(type, category, operationtype, inputs, outputs) {
+    constructor(category, operationtype, inputs, outputs) {
         this.width = 150;
         this.height = 200;
 
         this.x = endX - offsetX;
         this.y = endY - offsetY;
 
-        this.type = type;
         this.category = category;
         this.inputs = [];
         this.outputs = [];
@@ -158,11 +156,11 @@ class Node {
         this.drawNodules(ctx, x, y);
 
         // Draw the "box" used for input or function types
-        if (this.type === "Input" || this.type === "Variable") {
+        if (this instanceof ValueNode) {
             this.drawBox(ctx, x, y, 155, 75, 170, "center");
         }
 
-        if (this.type === "Function") {
+        if (this instanceof FunctionNode) {
             this.drawBox(ctx, x, y, 75, 27, 90, "left");
         }
     }

--- a/editor/uiclasses.js
+++ b/editor/uiclasses.js
@@ -389,6 +389,10 @@ class OutputNode extends Node {
     }
 
     getAsymptotes(xMin, xMax) {
+        if (this.inputs[0].connection === null) {
+            return [];
+        }
+
         return this.inputs[0].connection.parent.getAsymptotes(xMin, xMax);
     }
 }

--- a/editor/uiclasses.js
+++ b/editor/uiclasses.js
@@ -433,11 +433,6 @@ function nthCosineZero(func, x) {
 }
 
 
-function getDerivative(funcStr) {
-    return nerdamer.diff(funcStr, "x");
-}
-
-
 function getFunctionInverse(funcStr) {
     funcStr = "y = " + funcStr;
 

--- a/editor/uiclasses.js
+++ b/editor/uiclasses.js
@@ -204,8 +204,6 @@ class Node {
         }
 
         let formula = this.getFormula();
-        console.log(formula);
-        console.log(typeof formula);
 
         for (const key in replaceMap) {
             formula = formula.replaceAll(key, replaceMap[key]);

--- a/editor/uiclasses.js
+++ b/editor/uiclasses.js
@@ -1,27 +1,47 @@
 class Nodule {
-    constructor(isInput, name, value, parent) {
+    HITBOX_RADIUS = 10;
+
+    constructor(isInput, name, value, parent, index) {
         this.isInput = isInput;
         this.name = name;
         this.connection = null;
         this.parent = parent;
+        this.index = index;
+
+        // defines x and y
+        this.refreshPos();
     }
 
-    draw(ctx, x, y, index, blockWidth, blockHeight) {
-        let xOffset = this.isInput ? 1 : blockWidth - 1;
-        let yOffset = this.isInput ? -25 * index + blockHeight - 30 : 25 * index + 55;
+    /**
+     * Refreshes the position based on the parent NodeBlock.
+     */
+    refreshPos() {
+        let xOffset = this.isInput ? 1 : this.parent.width - 1;
+        let yOffset = this.isInput ? -25 * this.index + this.parent.height - 30 : 25 * this.index + 55;
+
+        this.x = this.parent.x + xOffset;
+        this.y = this.parent.y + yOffset;
+    }
+
+    draw(ctx) {
+        this.refreshPos();
 
         ctx.fillStyle = '#9f9f9f';
-        drawCircle(ctx, x + xOffset, y + yOffset, 6);
+        drawCircle(ctx, this.x, this.y, 6);
         ctx.fill();
         ctx.stroke();
-
-        xOffset += this.isInput ? 10 : -10;
 
         ctx.fillStyle = "white";
         ctx.font = "14px Poppins";
         ctx.textAlign = this.isInput ? "left" : "right";
         ctx.textBaseline = "middle";
-        ctx.fillText(this.name, x + xOffset, y + yOffset);
+
+        let textOffset = this.isInput ? 10 : -10;
+        ctx.fillText(this.name, this.x + textOffset, this.y);
+    }
+
+    collidesWith(x, y) {
+        return (this.x - x) ** 2 + (this.y - y) ** 2 < this.HITBOX_RADIUS ** 2;
     }
 }
 
@@ -44,12 +64,12 @@ class Node {
         this.outputs = [];
         this.operationtype = operationtype;
 
-        inputs.forEach(input => {
-            this.inputs.push(new Nodule(true, input.name, input.value, this));
+        inputs.forEach((input, index) => {
+            this.inputs.push(new Nodule(true, input.name, input.value, this, index));
         })
 
-        outputs.forEach(output => {
-            this.outputs.push(new Nodule(false, output.name, output.value, this));
+        outputs.forEach((output, index) => {
+            this.outputs.push(new Nodule(false, output.name, output.value, this, index));
         });
     }
 
@@ -184,6 +204,8 @@ class Node {
         }
 
         let formula = this.getFormula();
+        console.log(formula);
+        console.log(typeof formula);
 
         for (const key in replaceMap) {
             formula = formula.replaceAll(key, replaceMap[key]);
@@ -230,8 +252,8 @@ class Node {
 }
 
 class ValueNode extends Node {
-    constructor(type, category, operationtype, inputs, outputs) {
-        super(type, category, operationtype, inputs, outputs);
+    constructor(category, operationtype, inputs, outputs) {
+        super(category, operationtype, inputs, outputs);
         this.value = operationtype;
     }
 
@@ -245,8 +267,8 @@ class ValueNode extends Node {
 }
 
 class FunctionNode extends Node {
-    constructor(type, category, operationtype, inputs, outputs) {
-        super(type, category, operationtype, inputs, outputs);
+    constructor(category, operationtype, inputs, outputs) {
+        super(category, operationtype, inputs, outputs);
 
         console.log(getZeros("x^2 - 4"));
     }
@@ -354,8 +376,8 @@ class FunctionNode extends Node {
 }
 
 class OutputNode extends Node {
-    constructor(type, category, operationtype, inputs, outputs) {
-        super(type, category, operationtype, inputs, outputs);
+    constructor(category, operationtype, inputs, outputs) {
+        super(category, operationtype, inputs, outputs);
     }
 
     getFormula() {

--- a/editor/uiclasses.js
+++ b/editor/uiclasses.js
@@ -200,6 +200,35 @@ class Node {
     getAsymptotes(xMin, xMax) {
         throw new Error("This method must be overridden in a subclass");
     }
+
+    cycleNodeType() {
+        //x + 15, y + 75, blockWidth - 30, blockHeight - 170
+        // Exit if the mouse is not within the bounds of the box
+        if (startX < this.x + 15 + offsetX ||
+            startX > this.x + 150 - 15 + offsetX ||
+            startY < this.y + 75 + offsetY ||
+            startY > this.y + 200 - 100 + offsetY)
+        {
+            return;
+        }
+
+        let operationsByCategory = {
+            "Arithmetic": ["Add", "Subtract", "Multiply", "Divide", "Exponent", "Modulus", "Radical", "Logarithm"],
+            "Unary Operators": ["Absolute Value", "Ceiling", "Floor"],
+            "Trigonometry": ["Sine", "Cosine", "Tangent", "Cosecant", "Secant", "Cotangent"]
+        }
+
+        let operations = operationsByCategory[this.category];
+        let operationTypeIndex = operations.indexOf(this.operationtype);
+        let newOperationIndex = operationTypeIndex + 1;
+
+        // "Roll over" the operations array
+        if (newOperationIndex === operations.length - 1) {
+            newOperationIndex = 0;
+        }
+
+        this.operationtype = operations[newOperationIndex];
+    }
 }
 
 class ValueNode extends Node {

--- a/editor/uiclasses.js
+++ b/editor/uiclasses.js
@@ -247,6 +247,26 @@ class Node {
 
         this.operationtype = operations[newOperationIndex];
     }
+
+    inputNoduleAt(x, y) {
+        for (const nodule of this.inputs) {
+            if (nodule.collidesWith(x, y)) {
+                return nodule;
+            }
+        }
+
+        return null;
+    }
+
+    outputNoduleAt(x, y) {
+        for (const nodule of this.outputs) {
+            if (nodule.collidesWith(x, y)) {
+                return nodule;
+            }
+        }
+
+        return null;
+    }
 }
 
 class ValueNode extends Node {

--- a/editor/uiclasses.js
+++ b/editor/uiclasses.js
@@ -64,11 +64,11 @@ class Node {
         this.outputs = [];
         this.operationtype = operationtype;
 
-        inputs.forEach((input, index) => {
+        inputs.toReversed().forEach((input, index) => {
             this.inputs.push(new Nodule(true, input.name, input.value, this, index));
         })
 
-        outputs.forEach((output, index) => {
+        outputs.toReversed().forEach((output, index) => {
             this.outputs.push(new Nodule(false, output.name, output.value, this, index));
         });
     }


### PR DESCRIPTION
Fixes the `Arithmetic` node (and any other node with multiple inputs) having the nodes flipped.

![image](https://github.com/makaip/mathematix/assets/98898166/58f1fd81-f9df-442e-95bd-6a2afee34687)

NOTE: this branch is a branch of the refactored code. Merging this before the refactor PR may cause issues.